### PR TITLE
Clarify expression for arbitrary-length tuples

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -314,10 +314,10 @@ holds a set of classes representing builtin types with generics, namely:
 
 * FrozenSet, used as ``FrozenSet[element_type]``
 
-* Tuple, used as ``Tuple[index0_type, index1_type, ...]``.
-  Arbitrary-length tuples might be expressed using ellipsis, in which
-  case the following arguments are considered the same type as the last
-  defined type on the tuple.
+* Tuple, used by listing the element types (for example
+  ``Tuple[str, int, str]``).
+  Arbitrary-length homogeneous are expressed using one type and ellipsis,
+  as in ``Tuple[int, ...]``.
 
 It also introduces factories and helper members needed to express
 generics and union types:


### PR DESCRIPTION
This is hopefully clearer, and it rules out things like `Tuple[t1, ..., t2]`.