### PR TITLE
Replace comments with string literals

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -260,9 +260,9 @@ hinting, use the following:
 
 * a ``@no_type_checks`` decorator on classes and functions
 
-* a ``# type: ignore`` comment on arbitrary lines
+* a ``'''type: ignore'''`` string literal on arbitrary lines
 
-.. FIXME: should we have a module-wide comment as well?
+.. FIXME: should we have a module-wide string literals as well?
 
 
 Type Hints on Local and Global Variables
@@ -272,14 +272,16 @@ No first-class syntax support for explicitly marking variables as being
 of a specific type is added by this PEP.  To help with type inference in
 complex cases, a comment of the following format may be used::
 
-  x = []   # type: List[Employee]
+  '''type: List[Employee]'''
+  x = []
 
 In the case where type information for a local variable is needed before
 if was declared, an ``Undefined`` placeholder might be used::
 
   from typing import Undefined
-
-  x = Undefined   # type: List[Employee]
+  
+  '''type: List[Employee]'''
+  x = Undefined
   y = Undefined(int)
 
 If type hinting proves useful in general, a syntax for typing variables
@@ -327,9 +329,12 @@ generics and union types:
 * TypeVar, used as ``X = TypeVar('X', Type1, Type2, Type3)`` or simply
   ``Y = TypeVar('Y')``
 
-* Undefined, used as ``local_variable = Undefined # type: List[int]`` or
-  ``local_variable = Undefined(List[int])`` (the latter being slower
-  during runtime)
+* Undefined, used as ``local_variable = Undefined(List[int])`` or::
+
+    '''type: List[int]'''
+    local_variable = Undefined
+  
+  (the former being slower during runtime)
 
 * Callable, used as ``Callable[[Arg1Type, Arg2Type], ReturnType]``
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -270,7 +270,7 @@ Type Hints on Local and Global Variables
 
 No first-class syntax support for explicitly marking variables as being
 of a specific type is added by this PEP.  To help with type inference in
-complex cases, a comment of the following format may be used::
+complex cases, a string literal of the following format may be used::
 
   '''type: List[Employee]'''
   x = []


### PR DESCRIPTION
As outlined in #35, both `assert isinstance(…)` and syntactically relevant comments have severe drawbacks.

Parallel to docstrings, using string literals for inline type hinting provides hints that eliminate those disadvantages:

1. they appear in the standard  Python AST and are therefore easier to retrieve (no 3rd party AST necessary)
2. no significant runtime cost (like `assert isinstance(…)` or `Undefined(…)` have)
3. equally lightweight syntax as comments (triple quouted or single quoted string literals instead of comment)

Also they are already used in e.g. PyCharm’s type hinting.

Open question: Do we prefer

```python
'''type: List[Employee]'''
x = []
```

or

```python
'type: List[Employee]'
x = []
```