### PR TITLE
Specify that ABCs should be used in signatures

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -317,6 +317,12 @@ holds a set of classes representing builtin types with generics, namely:
   case the following arguments are considered the same type as the last
   defined type on the tuple.
 
+.. attention::
+   None of these is intended for use in function or method signatures.
+   Unless the function needs methods that ``collections.abc`` does not
+   provide, function signatures should always use the abstract classes
+   ``Sequence``, ``Mapping``, ``AbstractSet`` and so on.
+
 It also introduces factories and helper members needed to express
 generics and union types:
 


### PR DESCRIPTION
As discussed in #12, concrete types are useful as return values or inline variables, but bad in function signatures, as most functions will e.g. loop over their sequence arguments, or index into it, instead of mutating them by invoking `sort` on them (`sorted` works on `Sequence`s anyway!) or concatenating them via `+`.

It’s not part of the Zen Of Python, but [the robustness principle](https://en.wikipedia.org/wiki/Robustness_principle) is good to adhere to:

> Be conservative in what you send, be liberal in what you accept