### PR TITLE
"what is OK as a hint" vs "how to write a hint"

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -152,9 +152,12 @@ Type hints may be built-in classes (including those defined in
 standard library or third-party extension modules), abstract base
 classes, types available in the ``types`` module, and user-defined
 classes (including those defined in the standard library or
-third-party modules).  Annotations for built-in classes (and other
-classes at the discretion of the developer) may be placed in stub
-files (see below).
+third-party modules).  
+
+While annotations are normally the best format for type hints, 
+there are times when it is more appropriate to represent them
+by a special comment, or in a separately distributed interface 
+file.  (See below for examples.)
 
 Annotations must be valid expressions that evaluate without raising
 exceptions at the time the function is defined (but see below for

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -176,7 +176,7 @@ below may be used: ``None``, ``Any``, ``Union``, ``Tuple``,
 from ``typing`` (e.g. ``Sequence`` and ``Dict``), type variables, and
 type aliases.
 
-All newly introducedw names used to support features described in
+All newly introduced names used to support features described in
 following sections (such as ``Any`` and ``Union``) are available in
 the ``typing`` module.
 
@@ -1003,7 +1003,7 @@ Most people are familiar with the use of angular brackets
 express the parametrization of generic types.  The problem with these
 is that they are really hard to parse, especially for a simple-minded
 parser like Python.  In most languages the ambiguities are usually
-dealy with by only allowing angular brackets in specific syntactic
+dealt with by only allowing angular brackets in specific syntactic
 positions, where general expressions aren't allowed.  (And also by
 using very powerful parsing techniques that can backtrack over an
 arbitrary section of code.)
@@ -1165,7 +1165,7 @@ evaluation.  There are several things wrong with this idea, however.
   well known from other programming languages.  But this use of ``::``
   is unheard of in English, and in other languages (e.g. C++) it is
   used as a scoping operator, which is a very different beast.  In
-  contrast, the single colon for type hints reads natural -- and no
+  contrast, the single colon for type hints reads naturally -- and no
   wonder, since it was carefully designed for this purpose (the idea
   long predates PEP 3107 [gvr-artima]_).  It is also used in the same
   fashion in other languages from Pascal to Swift.


### PR DESCRIPTION
Break apart the lists of what what is OK as a hint (classes, etc) from how the hints are represented (annotation, comment, stub/interface file)