### PR TITLE
Always call stub files stub (not interface) files.

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -158,8 +158,8 @@ third-party modules).
 
 While annotations are normally the best format for type hints,
 there are times when it is more appropriate to represent them
-by a special comment, or in a separately distributed interface
-file.  (See below for examples.)
+by a special comment, or in a separately distributed stub file.
+(See below for examples.)
 
 Annotations must be valid expressions that evaluate without raising
 exceptions at the time the function is defined (but see below for


### PR DESCRIPTION
There's one place where stub files are called interface files (which was a proposed alternative which was ignored/rejected - though I prefer stub anyways).

Either way, they should be called the same everywhere to avoid confusion.