### PR TITLE
Prohibit Generic[T,T]

### DIFF
--- a/prototyping/test_typing.py
+++ b/prototyping/test_typing.py
@@ -557,8 +557,11 @@ class GenericTests(TestCase):
 
     def test_init(self):
         T = TypeVar('T')
+        S = TypeVar('S')
         with self.assertRaises(TypeError):
             Generic[T, T]
+        with self.assertRaises(TypeError):
+            Generic[T, S, T]
 
     def test_repr(self):
         self.assertEqual(repr(SimpleMapping),

--- a/prototyping/test_typing.py
+++ b/prototyping/test_typing.py
@@ -555,6 +555,11 @@ class GenericTests(TestCase):
         with self.assertRaises(TypeError):
             Y[str, bytes]
 
+    def test_init(self):
+        T = TypeVar('T')
+        with self.assertRaises(TypeError):
+            Generic[T, T]
+
     def test_repr(self):
         self.assertEqual(repr(SimpleMapping),
                          __name__ + '.' + 'SimpleMapping[~XK, ~XV]')

--- a/prototyping/typing.py
+++ b/prototyping/typing.py
@@ -1310,7 +1310,7 @@ class MutableSet(AbstractSet[T], extra=collections_abc.MutableSet):
 
 
 # NOTE: Only the value type is covariant.
-class Mapping(Sized, Iterable[KT], Container[KT], Generic[KT, VT_co],
+class Mapping(Sized, Iterable[KT], Container[KT], Generic[VT_co],
               extra=collections_abc.Mapping):
     pass
 

--- a/prototyping/typing.py
+++ b/prototyping/typing.py
@@ -947,6 +947,8 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                 if not isinstance(p, TypeVar):
                     raise TypeError("Initial parameters must be "
                                     "type variables; got %s" % p)
+            if len(set(params)) != len(params):
+                raise TypeError("All type variables in Generic[...] must be distinct.")
         else:
             if len(params) != len(self.__parameters__):
                 raise TypeError("Cannot change parameter count from %d to %d" %


### PR DESCRIPTION
A simple-minded fix that prohibits Generic[T, T] and makes a minor change discussed in the same issue #134 .