### PR TITLE
Don't iterate over ellipsis in Callable when evaluating types. Fix #149

### DIFF
--- a/prototyping/test_typing.py
+++ b/prototyping/test_typing.py
@@ -459,6 +459,14 @@ class CallableTests(TestCase):
         ctv = Callable[..., str]
         self.assertEqual(repr(ctv), 'typing.Callable[..., str]')
 
+    def test_callable_with_ellipsis(self):
+
+        def foo(a: Callable[..., T]):
+            pass
+
+        self.assertEqual(get_type_hints(foo, globals(), locals()),
+                         {'a': Callable[..., T]})
+
 
 XK = TypeVar('XK', str, bytes)
 XV = TypeVar('XV')
@@ -800,6 +808,14 @@ class ForwardRefTests(TestCase):
 
         self.assertEqual(get_type_hints(foo, globals(), locals()),
                          {'a': Callable[[T], T]})
+
+    def test_callable_with_ellipsis_forward(self):
+
+        def foo(a: 'Callable[..., T]'):
+            pass
+
+        self.assertEqual(get_type_hints(foo, globals(), locals()),
+                         {'a': Callable[..., T]})
 
     def test_syntax_error(self):
 

--- a/prototyping/typing.py
+++ b/prototyping/typing.py
@@ -767,7 +767,10 @@ class CallableMeta(TypingMeta):
     def _eval_type(self, globalns, localns):
         if self.__args__ is None and self.__result__ is None:
             return self
-        args = [_eval_type(t, globalns, localns) for t in self.__args__]
+        if self.__args__ is Ellipsis:
+            args = self.__args__
+        else:
+            args = [_eval_type(t, globalns, localns) for t in self.__args__]
         result = _eval_type(self.__result__, globalns, localns)
         if args == self.__args__ and result == self.__result__:
             return self


### PR DESCRIPTION
See #149.