### PR TITLE
Use `__slots__` in `typing` module.

### DIFF
--- a/prototyping/typing.py
+++ b/prototyping/typing.py
@@ -128,6 +128,8 @@ class TypingMeta(type):
 class Final:
     """Mix-in class to prevent instantiation."""
 
+    __slots__ = ()
+
     def __new__(self, *args, **kwds):
         raise TypeError("Cannot instantiate %r" % self.__class__)
 
@@ -203,6 +205,8 @@ class _TypeAlias:
     some arbitrary class C) raises TypeError rather than returning
     False.
     """
+
+    __slots__ = ('name', 'type_var', 'impl_type', 'type_checker')
 
     def __new__(cls, *args, **kwds):
         """Constructor.
@@ -340,6 +344,8 @@ class Any(Final, metaclass=AnyMeta, _root=True):
     - Any class is a subclass of Any.
     - As a special case, Any and object are subclasses of each other.
     """
+
+    __slots__ = ()
 
 
 class TypeVar(TypingMeta, metaclass=TypingMeta, _root=True):
@@ -635,6 +641,8 @@ class Optional(Final, metaclass=OptionalMeta, _root=True):
     Optional[X] is equivalent to Union[X, type(None)].
     """
 
+    __slots__ = ()
+
 
 class TupleMeta(TypingMeta):
     """Metaclass for Tuple."""
@@ -733,6 +741,8 @@ class Tuple(Final, metaclass=TupleMeta, _root=True):
 
     To specify a variable-length tuple of homogeneous type, use Sequence[T].
     """
+
+    __slots__ = ()
 
 
 class CallableMeta(TypingMeta):
@@ -839,6 +849,8 @@ class Callable(Final, metaclass=CallableMeta, _root=True):
     There is no syntax to indicate optional or keyword arguments,
     such function types are rarely used as callback types.
     """
+
+    __slots__ = ()
 
 
 def _gorg(a):
@@ -1042,6 +1054,8 @@ class Generic(metaclass=GenericMeta):
           # Same body as above.
     """
 
+    __slots__ = ()
+
     def __new__(cls, *args, **kwds):
         next_in_mro = object
         # Look for the last occurrence of Generic or Generic[...].
@@ -1208,6 +1222,7 @@ class _ProtocolMeta(GenericMeta):
                         attr != '__abstractmethods__' and
                         attr != '_is_protocol' and
                         attr != '__dict__' and
+                        attr != '__slots__' and
                         attr != '_get_protocol_attrs' and
                         attr != '__parameters__' and
                         attr != '__origin__' and
@@ -1225,6 +1240,8 @@ class _Protocol(metaclass=_ProtocolMeta):
     such as Hashable).
     """
 
+    __slots__ = ()
+
     _is_protocol = True
 
 
@@ -1235,14 +1252,15 @@ Hashable = collections_abc.Hashable  # Not generic.
 
 
 class Iterable(Generic[T_co], extra=collections_abc.Iterable):
-    pass
+    __slots__ = ()
 
 
 class Iterator(Iterable[T_co], extra=collections_abc.Iterator):
-    pass
+    __slots__ = ()
 
 
 class SupportsInt(_Protocol):
+    __slots__ = ()
 
     @abstractmethod
     def __int__(self) -> int:
@@ -1250,6 +1268,7 @@ class SupportsInt(_Protocol):
 
 
 class SupportsFloat(_Protocol):
+    __slots__ = ()
 
     @abstractmethod
     def __float__(self) -> float:
@@ -1257,6 +1276,7 @@ class SupportsFloat(_Protocol):
 
 
 class SupportsComplex(_Protocol):
+    __slots__ = ()
 
     @abstractmethod
     def __complex__(self) -> complex:
@@ -1264,6 +1284,7 @@ class SupportsComplex(_Protocol):
 
 
 class SupportsBytes(_Protocol):
+    __slots__ = ()
 
     @abstractmethod
     def __bytes__(self) -> bytes:
@@ -1271,6 +1292,7 @@ class SupportsBytes(_Protocol):
 
 
 class SupportsAbs(_Protocol[T]):
+    __slots__ = ()
 
     @abstractmethod
     def __abs__(self) -> T:
@@ -1278,6 +1300,7 @@ class SupportsAbs(_Protocol[T]):
 
 
 class SupportsRound(_Protocol[T]):
+    __slots__ = ()
 
     @abstractmethod
     def __round__(self, ndigits: int = 0) -> T:
@@ -1285,6 +1308,7 @@ class SupportsRound(_Protocol[T]):
 
 
 class Reversible(_Protocol[T]):
+    __slots__ = ()
 
     @abstractmethod
     def __reversed__(self) -> 'Iterator[T]':
@@ -1295,7 +1319,7 @@ Sized = collections_abc.Sized  # Not generic.
 
 
 class Container(Generic[T_co], extra=collections_abc.Container):
-    pass
+    __slots__ = ()
 
 
 # Callable was defined earlier.
@@ -1369,6 +1393,7 @@ class _FrozenSetMeta(GenericMeta):
 
 
 class FrozenSet(frozenset, AbstractSet[T_co], metaclass=_FrozenSetMeta):
+    __slots__ = ()
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, FrozenSet):
@@ -1416,6 +1441,7 @@ else:
 
 class Generator(Iterator[T_co], Generic[T_co, T_contra, V_co],
                 extra=_G_base):
+    __slots__ = ()
 
     def __new__(cls, *args, **kwds):
         if _geqv(cls, Generator):
@@ -1458,6 +1484,8 @@ class IO(Generic[AnyStr]):
     pervasive in the interface; however we currently do not offer a
     way to track the other distinctions in the type system.
     """
+
+    __slots__ = ()
 
     @abstractproperty
     def mode(self) -> str:
@@ -1543,6 +1571,8 @@ class IO(Generic[AnyStr]):
 class BinaryIO(IO[bytes]):
     """Typed version of the return of open() in binary mode."""
 
+    __slots__ = ()
+
     @abstractmethod
     def write(self, s: Union[bytes, bytearray]) -> int:
         pass
@@ -1554,6 +1584,8 @@ class BinaryIO(IO[bytes]):
 
 class TextIO(IO[str]):
     """Typed version of the return of open() in text mode."""
+
+    __slots__ = ()
 
     @abstractproperty
     def buffer(self) -> BinaryIO:


### PR DESCRIPTION
This is primarily useful for subclassing `Generic[T]`, but it's easiest
to do it all at once.